### PR TITLE
Support `fs-group` annotation to add PodSecurityPolicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ This webhook is for mutating pods that will require AWS IAM access.
       annotations:
         eks.amazonaws.com/role-arn: "arn:aws:iam::111122223333:role/s3-reader"
     ```
-4. All new pod pods launched using this Service Account will be modified to use
+4. Optionally, add the `eks.amazonaws.com/fs-group` annotation to the service
+   account or to the pod's annotations with an integer GID. This will add a
+   `PodSecurityPolicy` with that GID as the `fsGroup` to applicable pods. This
+   is necessary for non-root containers to access the projected service account
+   token which will be owned by root with 0600 permissions.
+5. All new pod pods launched using this Service Account will be modified to use
    IAM for pods. Below is an example pod spec with the environment variables and
    volume fields added by the webhook.
     ```yaml

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	saCache.Start()
 
 	mod := handler.NewModifier(
+		handler.WithAnnotationPrefix(*annotationPrefix),
 		handler.WithExpiration(*tokenExpiration),
 		handler.WithMountPath(*mountPath),
 		handler.WithServiceAccountCache(saCache),
@@ -123,7 +124,6 @@ func main() {
 	metricsMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-
 
 	tlsConfig := &tls.Config{}
 
@@ -180,8 +180,8 @@ func main() {
 	handler.ShutdownOnTerm(server, time.Duration(10)*time.Second)
 
 	metricsServer := &http.Server{
-		Addr:      metricsAddr,
-		Handler:   metricsMux,
+		Addr:    metricsAddr,
+		Handler: metricsMux,
 	}
 
 	go func() {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -11,7 +12,11 @@ func TestSaCache(t *testing.T) {
 	testSA.Name = "default"
 	testSA.Namespace = "default"
 	roleArn := "arn:aws:iam::111122223333:role/s3-reader"
-	testSA.Annotations = map[string]string{"eks.amazonaws.com/role-arn": roleArn}
+	var fsGroup int64 = 12345
+	testSA.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn": roleArn,
+		"eks.amazonaws.com/fs-group": fmt.Sprintf("%d", fsGroup),
+	}
 
 	cache := &serviceAccountCache{
 		cache:            map[string]*CacheResponse{},
@@ -19,20 +24,21 @@ func TestSaCache(t *testing.T) {
 		annotationPrefix: "eks.amazonaws.com",
 	}
 
-	role, aud := cache.Get("default", "default")
-
-	if role != "" || aud != "" {
-		t.Errorf("Expected role and aud to be empty, got %s, %s", role, aud)
+	role, aud, fsg := cache.Get("default", "default")
+	if role != "" || aud != "" || fsg != nil {
+		t.Errorf("Expected role, aud and fsg to be empty, got %s, %s, %d", role, aud, *fsg)
 	}
 
 	cache.addSA(testSA)
 
-	role, aud = cache.Get("default", "default")
+	role, aud, fsg = cache.Get("default", "default")
 	if role != roleArn {
 		t.Errorf("Expected role to be %s, got %s", roleArn, role)
 	}
 	if aud != "sts.amazonaws.com" {
 		t.Errorf("Expected aud to be sts.amzonaws.com, got %s", aud)
 	}
-
+	if *fsg != fsGroup {
+		t.Errorf("Expected fsg to be %d, got %d", fsGroup, *fsg)
+	}
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
@@ -69,14 +70,20 @@ func WithRegion(region string) ModifierOpt {
 	return func(m *Modifier) { m.Region = region }
 }
 
+// WithAnnotationPrefix sets the pod annotation prefix
+func WithAnnotationPrefix(prefix string) ModifierOpt {
+	return func(m *Modifier) { m.AnnotationPrefix = prefix }
+}
+
 // NewModifier returns a Modifier with default values
 func NewModifier(opts ...ModifierOpt) *Modifier {
 
 	mod := &Modifier{
-		MountPath:  "/var/run/secrets/eks.amazonaws.com/serviceaccount",
-		Expiration: 86400,
-		volName:    "aws-iam-token",
-		tokenName:  "token",
+		AnnotationPrefix: "eks.amazonaws.com",
+		MountPath:        "/var/run/secrets/eks.amazonaws.com/serviceaccount",
+		Expiration:       86400,
+		volName:          "aws-iam-token",
+		tokenName:        "token",
 	}
 	for _, opt := range opts {
 		opt(mod)
@@ -87,12 +94,13 @@ func NewModifier(opts ...ModifierOpt) *Modifier {
 
 // Modifier holds configuration values for pod modifications
 type Modifier struct {
-	Expiration int64
-	MountPath  string
-	Region     string
-	Cache      cache.ServiceAccountCache
-	volName    string
-	tokenName  string
+	AnnotationPrefix string
+	Expiration       int64
+	MountPath        string
+	Region           string
+	Cache            cache.ServiceAccountCache
+	volName          string
+	tokenName        string
 }
 
 type patchOperation struct {
@@ -173,7 +181,40 @@ func addEnvToContainer(container *corev1.Container, mountPath, tokenFilePath, vo
 	)
 }
 
-func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []patchOperation {
+// addFSGroupToPod adds an `fsGroup` to the PodSecurityContext and returns the
+// `corev1.PodSecurityContext` to use in a patch OR nil if no patch is needed.
+func (m *Modifier) addFSGroupToPod(pod *corev1.Pod, fsGroup *int64) *corev1.PodSecurityContext {
+	// Any `fs-group` annotations on a pod takes precedence over a
+	// ServiceAccount `fs-group` annotation
+	if fsgStr, ok := pod.Annotations[m.AnnotationPrefix+"/fs-group"]; ok {
+		if fsgInt, err := strconv.ParseInt(fsgStr, 10, 64); err == nil {
+			fsGroup = &fsgInt
+		}
+	}
+
+	// Don't patch if an fsGroup isn't set via an annotation
+	if fsGroup == nil {
+		return nil
+	}
+
+	// If a PodSecurityContext exists, only add fsGroup if one isn't set.
+	sc := pod.Spec.SecurityContext
+	if sc != nil {
+		if sc.FSGroup == nil {
+			sc.FSGroup = fsGroup
+			return sc
+		}
+		return nil
+	}
+
+	// Otherwise, add a new PodSecurityContext with our fsGroup.
+	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+		FSGroup: fsGroup,
+	}
+	return pod.Spec.SecurityContext
+}
+
+func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, fsGroup *int64) []patchOperation {
 	// return early if volume already exists
 	for _, vol := range pod.Spec.Volumes {
 		if vol.Name == m.volName {
@@ -222,6 +263,8 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []p
 		},
 	}
 
+	securityContext := m.addFSGroupToPod(pod, fsGroup)
+
 	patch := []patchOperation{
 		{
 			Op:    "add",
@@ -255,6 +298,15 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []p
 			Value: initContainers,
 		})
 	}
+
+	if securityContext != nil {
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  "/spec/securityContext",
+			Value: securityContext,
+		})
+	}
+
 	return patch
 }
 
@@ -286,7 +338,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 
 	pod.Namespace = req.Namespace
 
-	podRole, audience := m.Cache.Get(pod.Spec.ServiceAccountName, pod.Namespace)
+	podRole, audience, fsGroup := m.Cache.Get(pod.Spec.ServiceAccountName, pod.Namespace)
 
 	// determine whether to perform mutation
 	if podRole == "" {
@@ -295,7 +347,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 		}
 	}
 
-	patchBytes, err := json.Marshal(m.updatePodSpec(&pod, podRole, audience))
+	patchBytes, err := json.Marshal(m.updatePodSpec(&pod, podRole, audience, fsGroup))
 	if err != nil {
 		klog.Errorf("Error marshaling pod update: %v", err.Error())
 		return &v1beta1.AdmissionResponse{

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -245,6 +245,75 @@ var rawPodWithAWSDefaultRegion = []byte(`
 }
 `)
 
+var rawPodWithoutFSGroup = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
+var rawPodWithFSGroup = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+    "securityContext": {
+      "fsGroup": 54321
+    },
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
+var rawPodWithFSGroupAnnotation = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "annotations": {
+      "eks.amazonaws.com/fs-group": "33333"
+    },
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+    "securityContext": {
+      "runAsUser": 2000
+    },
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
 func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	return &v1beta1.AdmissionReview{
 		Request: &v1beta1.AdmissionRequest{
@@ -278,6 +347,10 @@ var validPatchIfWindowsVolumesPresent = []byte(`[{"op":"add","path":"/spec/volum
 var validPatchIfNoRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfDefaultRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+
+var validPatchIfNoFSGroupPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/securityContext","value":{"fsGroup":12345}}]`)
+var validPatchIfFSGroupPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+var validPatchIfFSGroupAnnotationPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/securityContext","value":{"runAsUser":2000,"fsGroup":33333}}]`)
 
 var jsonPatchType = v1beta1.PatchType("JSONPatch")
 
@@ -327,6 +400,27 @@ var validResponseIfDefaultRegionPresent = &v1beta1.AdmissionResponse{
 	UID:       "",
 	Allowed:   true,
 	Patch:     validPatchIfDefaultRegionPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfNoFSGroupPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfNoFSGroupPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfFSGroupPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfFSGroupPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfFSGroupAnnotationPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfFSGroupAnnotationPresent,
 	PatchType: &jsonPatchType,
 }
 
@@ -439,6 +533,55 @@ func TestEnvUpdate(t *testing.T) {
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
 			getValidReview(rawPodWithAWSDefaultRegion),
 			validResponseIfDefaultRegionPresent,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			response := c.modifier.MutatePod(c.input)
+
+			if !reflect.DeepEqual(response, c.response) {
+				got, _ := json.MarshalIndent(response, "", "  ")
+				want, _ := json.MarshalIndent(c.response, "", "  ")
+				t.Errorf("Unexpected response. Got \n%s\n wanted \n%s", string(got), string(want))
+			}
+
+		})
+	}
+}
+
+func TestFSGroupUpdate(t *testing.T) {
+	testServiceAccount := &v1.ServiceAccount{}
+	testServiceAccount.Name = "fsgroup"
+	testServiceAccount.Namespace = "default"
+	testServiceAccount.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader",
+		"eks.amazonaws.com/fs-group": "12345",
+	}
+
+	cases := []struct {
+		caseName string
+		modifier *Modifier
+		input    *v1beta1.AdmissionReview
+		response *v1beta1.AdmissionResponse
+	}{
+		{
+			"ValidRequestSuccessWithoutFSGroup",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithoutFSGroup),
+			validResponseIfNoFSGroupPresent,
+		},
+		{
+			"ValidRequestSuccessWithFSGroup",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithFSGroup),
+			validResponseIfFSGroupPresent,
+		},
+		{
+			"ValidRequestSuccessWithFSGroupAnnotation",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithFSGroupAnnotation),
+			validResponseIfFSGroupAnnotationPresent,
 		},
 	}
 


### PR DESCRIPTION
Allows setting `eks.amazonaws.com/fs-group` annotation on a
ServiceAccount or Pod. This will add an `fsGroup` with the
GID from the annotation into the PodSecurityPolicies. This
allows non-root containers to access the VolumeMount which
is owned by root with 600 permissions.
