### PR TITLE
Support `fs-group` annotation to add PodSecurityPolicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ This webhook is for mutating pods that will require AWS IAM access.
         #         annotation as shown in the next step.
         eks.amazonaws.com/token-expiration: "86400"
     ```
-4. All new pod pods launched using this Service Account will be modified to use
+4. Optionally, add the `eks.amazonaws.com/fs-group` annotation to the service
+   account or to the pod's annotations with an integer GID. This will add a
+   `PodSecurityPolicy` with that GID as the `fsGroup` to applicable pods. This
+   is necessary for non-root containers to access the projected service account
+   token which will be owned by root with 0600 permissions.
+5. All new pod pods launched using this Service Account will be modified to use
    IAM for pods. Below is an example pod spec with the environment variables and
    volume fields added by the webhook.
     ```yaml

--- a/pkg/annotations.go
+++ b/pkg/annotations.go
@@ -26,4 +26,7 @@ const (
 
 	// A comma-separated list of container names to skip adding environment variables and volumes to. Applies to `initContainers` and `containers`
 	SkipContainersAnnotation = "skip-containers"
+
+	// FSGroup Annotation
+	FSGroupAnnotation = "fs-group"
 )

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -131,8 +131,12 @@ func (c *serviceAccountCache) addSA(sa *v1.ServiceAccount) {
 				resp.TokenExpiration = pkg.ValidateMinTokenExpiration(tokenExpiration)
 			}
 		}
-		if fsgStr, ok := sa.Annotations[c.annotationPrefix+"/fs-group"]; ok {
-			if fsgInt, err := strconv.ParseInt(fsgStr, 10, 64); err == nil {
+
+		if fsgStr, ok := sa.Annotations[c.annotationPrefix+"/"+pkg.FSGroupAnnotation]; ok {
+			fsgInt, err := strconv.ParseInt(fsgStr, 10, 64)
+			if err != nil {
+				klog.V(4).Infof("Ignoring service account %s/%s invalid value for fs-group annotation", sa.Namespace, sa.Name)
+			} else {
 				resp.FSGroup = &fsgInt
 			}
 		}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -35,13 +35,14 @@ import (
 type CacheResponse struct {
 	RoleARN         string
 	Audience        string
+	FSGroup         *int64
 	UseRegionalSTS  bool
 	TokenExpiration int64
 }
 
 type ServiceAccountCache interface {
 	Start()
-	Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64)
+	Get(name, namespace string) (role, aud string, fsGroup *int64, useRegionalSTS bool, tokenExpiration int64)
 	// ToJSON returns cache contents as JSON string
 	ToJSON() string
 }
@@ -58,14 +59,19 @@ type serviceAccountCache struct {
 	defaultTokenExpiration int64
 }
 
-func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
+func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, fsGroup *int64, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
 	resp := c.get(name, namespace)
 	if resp == nil {
 		klog.V(4).Infof("Service account %s/%s not found in cache", namespace, name)
-		return "", "", false, pkg.DefaultTokenExpiration
+		return "", "", nil, false, pkg.DefaultTokenExpiration
 	}
-	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
+	// Immutable safety for the fsGroup *int64 in the cache
+	if resp.FSGroup != nil {
+		fsGroup = new(int64)
+		*fsGroup = *resp.FSGroup
+	}
+	return resp.RoleARN, resp.Audience, fsGroup, resp.UseRegionalSTS, resp.TokenExpiration
 }
 
 func (c *serviceAccountCache) get(name, namespace string) *CacheResponse {
@@ -123,6 +129,11 @@ func (c *serviceAccountCache) addSA(sa *v1.ServiceAccount) {
 				klog.V(4).Infof("Found invalid value for token expiration, using %d seconds as default: %v", resp.TokenExpiration, err)
 			} else {
 				resp.TokenExpiration = pkg.ValidateMinTokenExpiration(tokenExpiration)
+			}
+		}
+		if fsgStr, ok := sa.Annotations[c.annotationPrefix+"/fs-group"]; ok {
+			if fsgInt, err := strconv.ParseInt(fsgStr, 10, 64); err == nil {
+				resp.FSGroup = &fsgInt
 			}
 		}
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -259,7 +259,43 @@ func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath,
 	return changed
 }
 
-func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, regionalSTS bool, tokenExpiration int64) ([]patchOperation, bool) {
+// addFSGroupToPod adds an `fsGroup` to the PodSecurityContext and returns the
+// `corev1.PodSecurityContext` to use in a patch OR nil if no patch is needed.
+func (m *Modifier) addFSGroupToPod(pod *corev1.Pod, saFSGroup *int64) *corev1.PodSecurityContext {
+	fsGroup := saFSGroup
+
+	// Any `fs-group` annotations on a pod takes precedence over a
+	// ServiceAccount `fs-group` annotation
+	fsGroupKey := fmt.Sprintf("%s/%s", m.AnnotationDomain, pkg.FSGroupAnnotation)
+	if fsgStr, ok := pod.Annotations[fsGroupKey]; ok {
+		if fsgInt, err := strconv.ParseInt(fsgStr, 10, 64); err == nil {
+			fsGroup = &fsgInt
+		}
+	}
+
+	// Don't patch if an fsGroup isn't set via an annotation
+	if fsGroup == nil {
+		return nil
+	}
+
+	// If a PodSecurityContext exists, only add fsGroup if one isn't set.
+	sc := pod.Spec.SecurityContext
+	if sc != nil {
+		if sc.FSGroup == nil {
+			sc.FSGroup = fsGroup
+			return sc
+		}
+		return nil
+	}
+
+	// Otherwise, add a new PodSecurityContext with our fsGroup.
+	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+		FSGroup: fsGroup,
+	}
+	return pod.Spec.SecurityContext
+}
+
+func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, fsGroup *int64, regionalSTS bool, tokenExpiration int64) ([]patchOperation, bool) {
 	updateSettings := newPodUpdateSettings(m.AnnotationDomain, pod, regionalSTS)
 
 	tokenFilePath := filepath.Join(m.MountPath, m.tokenName)
@@ -313,6 +349,8 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, reg
 		},
 	}
 
+	securityContext := m.addFSGroupToPod(pod, fsGroup)
+
 	patch := []patchOperation{}
 
 	// skip adding volume if it already exists
@@ -357,6 +395,16 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, reg
 			Value: initContainers,
 		})
 	}
+
+	if securityContext != nil {
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  "/spec/securityContext",
+			Value: securityContext,
+		})
+		changed = true
+	}
+
 	return patch, changed
 }
 
@@ -388,7 +436,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 
 	pod.Namespace = req.Namespace
 
-	podRole, audience, regionalSTS, tokenExpiration := m.Cache.Get(pod.Spec.ServiceAccountName, pod.Namespace)
+	podRole, audience, fsGroup, regionalSTS, tokenExpiration := m.Cache.Get(pod.Spec.ServiceAccountName, pod.Namespace)
 
 	// determine whether to perform mutation
 	if podRole == "" {
@@ -403,7 +451,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 		}
 	}
 
-	patch, changed := m.updatePodSpec(&pod, podRole, audience, regionalSTS, tokenExpiration)
+	patch, changed := m.updatePodSpec(&pod, podRole, audience, fsGroup, regionalSTS, tokenExpiration)
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		klog.Errorf("Error marshaling pod update: %v", err.Error())

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -268,7 +268,10 @@ func (m *Modifier) addFSGroupToPod(pod *corev1.Pod, saFSGroup *int64) *corev1.Po
 	// ServiceAccount `fs-group` annotation
 	fsGroupKey := fmt.Sprintf("%s/%s", m.AnnotationDomain, pkg.FSGroupAnnotation)
 	if fsgStr, ok := pod.Annotations[fsGroupKey]; ok {
-		if fsgInt, err := strconv.ParseInt(fsgStr, 10, 64); err == nil {
+		fsgInt, err := strconv.ParseInt(fsgStr, 10, 64)
+		if err != nil {
+			klog.V(4).Infof("Ignoring pod %s/%s invalid value for fs-group annotation", pod.Namespace, pod.Name)
+		} else {
 			fsGroup = &fsgInt
 		}
 	}

--- a/pkg/handler/handler_pod_test.go
+++ b/pkg/handler/handler_pod_test.go
@@ -129,7 +129,7 @@ func TestHandlePod(t *testing.T) {
 					}
 				}
 
-				patch, _ := modifier.updatePodSpec(pod, roleARN, audience, useRegionalSTS, tokenExpiration)
+				patch, _ := modifier.updatePodSpec(pod, roleARN, audience, nil, useRegionalSTS, tokenExpiration)
 				patchBytes, err := json.Marshal(patch)
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
Original PR From Upstream: https://github.com/aws/amazon-eks-pod-identity-webhook/pull/86

A barrier to entry to using service account token volume projection is its root ownership with 0600 permissions by default (not customizable natively until Kubernetes v1.19?).

This leave two options, each with downsides:

Run the containers as root (not great from a security perspective)
Add a securityContext/fsGroup to the pod spec to grant a non-root container user access to the projected token (This is potentially difficult when integrating with upstream code or Helm charts).
This PR adds the ability to specify an eks.amazonaws.com/fs-group annotation on either the service account or the pod. The mutating webhook will add a securityContext/fsGroup in addition to the volume, mount & container env updates.

If securityContext/fsGroup is already configured on a pod, this does nothing. Existing fsGroup GID on the pod spec takes precedence
If the annotation is present on both the pod & its service account, the pod's annotation takes precedence
I've added unit tests in addition to manually testing all the configuration scenarios in a local development environment.
